### PR TITLE
Ansible 1.5.4 on Ubuntu 14.04 causes

### DIFF
--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -66,12 +66,12 @@
 
 - set_fact:
     ansible_distribution_major_version: >
-      {{ansible_distribution_version|truncate(2,true,'',0)|replace(".", " ")|trim|float|int|string}}
+      {{ansible_distribution_version|truncate(2,true,'')|replace(".", " ")|trim|float|int|string}}
   when: ansible_distribution_major_version is not defined
 
 - set_fact:
     ansible_distribution_major_version: >
-      {{ansible_distribution_version|truncate(4,true,'',0)|replace("."," ")|trim|float|int|string}}
+      {{ansible_distribution_version|truncate(4,true,'')|replace("."," ")|trim|float|int|string}}
   when: ansible_distribution_major_version is not defined or not ansible_distribution_major_version
 
 - name: check for wget


### PR DESCRIPTION
fatal: [localhost] => an unexpected type error occured. Error was
do_truncate() takes at most 4 arguments (5 given)